### PR TITLE
Catalog service docs

### DIFF
--- a/source/api.met.no.rst
+++ b/source/api.met.no.rst
@@ -1,12 +1,8 @@
 api.met.no
-^^^^^^^^^^^
-
-Heritage system: api.met.no
-"""""""""""""""""""""""""""
-
+==========
 
 Responsible (Who?)
-==================
+------------------
 
 .. Required. Who is responsible for this heritage system. This can be a
    group, a role or an administrative unit. Try to avoid linking to specific
@@ -15,7 +11,7 @@ Responsible (Who?)
 MET Norway, IT Department, Team Punkt.
 
 Description (What?)
-===================
+-------------------
 
 .. Required. Short description of the system:
    - what types of metadata is stored in this system.
@@ -36,7 +32,7 @@ but its not clear at the moment weather apis.json will co-exist with DCAT or be 
 
 
 Documentation(Where/how?)
-=========================
+-------------------------
 
 .. Required. Links to system dokumentation as comments, mark links that are
    only available for internal users
@@ -44,7 +40,7 @@ Documentation(Where/how?)
 api.met.no is documented with swagger and additional free text in html. See https://api.met.no for more information.
 
 Conditions and dependencies(why?)
-=================================
+---------------------------------
 
 .. Required. Please add a short paragraph explaining in words why the system is as it is
 

--- a/source/devel_docker_ci.rst
+++ b/source/devel_docker_ci.rst
@@ -259,7 +259,7 @@ Make a note of ``FIXME`` and ``TODO``. ``TODO`` marks where you need to update w
 Set Up Unit Testing
 -------------------
 
-Unit testing can be done in the same way as building containers. Please see a working example in the repository `steingod / mmd <https://github.com/steingod/mmd>`_.
+Unit testing can be done in the same way as building containers. Please see a working example in the repository `metno/mmd <https://github.com/metno/mmd>`_.
 
 Take note of the following files in the repository:
 

--- a/source/devel_environ.rst
+++ b/source/devel_environ.rst
@@ -197,3 +197,59 @@ To increase the capacity of the VM disk, you need the ``vagrant-disksize`` plugi
 
 ..
   # vim: set spell spelllang=en:
+
+--------------------------------------------------------------------------
+Development of the S-ENDA csw catalog service and relevant Python packages
+--------------------------------------------------------------------------
+
+The `S-ENDA csw catalog service <https://github.com/metno/S-ENDA-csw-catalog-service>`_ contains a Vagrant virtual machine configuration and a Docker container to run the catalog in a development environment that allows easy debugging of the relevant tools used by the service. All tools are downloaded to a folder called ``lib``, which is added in the vagrant shared folder (the root folder of the `S-ENDA csw catalog service <https://github.com/metno/S-ENDA-csw-catalog-service>`_ repository). You can then use your preferred editor to debug, change and update code. This is not intended for a regular user, but for people who wants to extend functionality or debug software.
+
+* Start VM:
+
+  .. code-block:: bash
+
+    vagrant up
+
+The csw-catalog-service is now started, and the catalog can be accessed on `<http://10.20.30.10>`_. Unless you have already ingested some metadata, the catalog should be empty.
+
+* Access VM:
+
+  .. code-block:: bash
+
+    vagrant ssh
+
+* Enter the docker container to run some code
+
+  .. code-block:: bash
+
+    sudo docker exec -it catalog-dev bash
+
+* Copy an example MMD xml file and test metadata ingestion
+
+  .. code-block:: bash
+
+    cp mmd/input-examples/sentinel-1-mmd.xml mmd_in/
+    cd mmd/bin/
+    # Translate from MMD to ISO19139
+    ./sentinel1_mmd_to_csw_iso19139.py -i ../../mmd_in -o ../../iso_out # OBS: the way to do this will change - NEEDS UPDATE
+    cd ../..
+    # Ingest the ISO19139 record(s)
+    python3 /usr/bin/pycsw-admin.py -c load_records -f /etc/pycsw/pycsw.cfg -p iso_out -r -y
+
+You can now search the metadata catalog, e.g., using `QGIS <https://qgis.org/en/site/>`_ (v3.14 or higher):
+
+* `Download and install QGIS <https://qgis.org/en/site/forusers/download.html>`_
+* Run ``qgis``
+* Select ``Web > MetaSearch > MetaSearch`` menu item
+* Select ``Services > New``
+* Type, e.g., ``testcatalog`` for the name
+* Type ``http://10.20.30.10`` for the URL
+* Under the ``Search`` tab, you can then add search parameters, click ``Search``, and get a list of available datasets.
+* Select a dataset
+* Click ``Add Data`` and select a WMS channel - the data will then be displayed in QGIS
+
+Contents of the S-ENDA-csw-catalog-service repository
+=====================================================
+
+* The file `pycsw_local.dev.cfg` is the pycsw configuration file used for local development. It contains configuration instructions to run the csw catalog service on your local Docker container which runs on the local virtual machine.
+

--- a/source/devel_environ.rst
+++ b/source/devel_environ.rst
@@ -256,7 +256,7 @@ The `S-ENDA csw catalog service <https://github.com/metno/S-ENDA-csw-catalog-ser
     # Ingest the ISO19139 record(s)
     python3 /usr/bin/pycsw-admin.py -c load_records -f /etc/pycsw/pycsw.cfg -p iso_out -r -y
     # Start the web server
-    python3 /usr/local/bin/entrypoint.py --reload
+    python3 /usr/local/bin/entrypoint.py
 
 The csw-catalog-service is now started, and the catalog can be accessed on `<http://10.20.30.11>`_. Unless you have already ingested some metadata, the catalog should be empty. You can search the metadata catalog using, e.g., `QGIS <https://qgis.org/en/site/>`_ (v3.14 or higher):
 

--- a/source/devel_environ.rst
+++ b/source/devel_environ.rst
@@ -279,6 +279,11 @@ Breakpoints are set by adding the following lines somewhere in the Python code:
   import ipdb
   ipdb.set_trace()
 
+Search, e.g., datasets within a given time span:
+
+* http://10.20.30.11/?mode=opensearch&service=CSW&version=2.0.2&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results&time=2000-01-01/2020-09-01
+
+
 To run tests:
 
 .. code-block:: bash
@@ -288,6 +293,7 @@ To run tests:
 .. note::
 
   Pytest runs all available test code. Currently it fails on ``/home/pycsw/mmd/tests/test__nc_to_mmd.py`` because netcdf4 is not installed. This is on the todo-list... See `<https://github.com/metno/S-ENDA-csw-catalog-service/issues/2>`_
+
 
 ..
   Contents of the S-ENDA-csw-catalog-service repository

--- a/source/devel_environ.rst
+++ b/source/devel_environ.rst
@@ -212,6 +212,10 @@ The `S-ENDA csw catalog service <https://github.com/metno/S-ENDA-csw-catalog-ser
 
 The csw-catalog-service is now started, and the catalog can be accessed on `<http://10.20.30.10>`_. Unless you have already ingested some metadata, the catalog should be empty.
 
+  .. note::
+
+    The git repositories with editable code is now available in the ``lib`` folder. If you need to add some repositories, please do it by editing the file ``build_container.dev.sh``
+
 * Access VM:
 
   .. code-block:: bash

--- a/source/devel_environ.rst
+++ b/source/devel_environ.rst
@@ -251,6 +251,8 @@ The `S-ENDA csw catalog service <https://github.com/metno/S-ENDA-csw-catalog-ser
     # Translate from MMD to ISO19139
     ./sentinel1_mmd_to_csw_iso19139.py -i ../../mmd_in -o ../../iso_out # OBS: the way to do this will change - NEEDS UPDATE
     cd ../..
+    # Create database
+    python3 /usr/bin/pycsw-admin.py -c setup_db -f /etc/pycsw/pycsw.cfg
     # Ingest the ISO19139 record(s)
     python3 /usr/bin/pycsw-admin.py -c load_records -f /etc/pycsw/pycsw.cfg -p iso_out -r -y
     # Start the web server

--- a/source/devel_environ.rst
+++ b/source/devel_environ.rst
@@ -202,15 +202,21 @@ To increase the capacity of the VM disk, you need the ``vagrant-disksize`` plugi
 Development of the S-ENDA csw catalog service and relevant Python packages
 --------------------------------------------------------------------------
 
+.. _local-developmen-env:
+
+Local development environment
+=============================
+
 The `S-ENDA csw catalog service <https://github.com/metno/S-ENDA-csw-catalog-service>`_ contains a Vagrant virtual machine configuration and a Docker container to run the catalog in a development environment that allows easy debugging of the relevant tools used by the service. All tools are downloaded to a folder called ``lib``, which is added in the vagrant shared folder (the root folder of the `S-ENDA csw catalog service <https://github.com/metno/S-ENDA-csw-catalog-service>`_ repository). You can then use your preferred editor to debug, change and update code. This is not intended for a regular user, but for people who wants to extend functionality or debug software.
 
+* Add MMD test files to ``lib/input_mmd_xml_files`` (this directory is accessible by the pycsw ``load_records`` command executed in ``catalog-service-api/pycsw_setup.sh``)
 * Start VM:
 
   .. code-block:: bash
 
-    vagrant up
+    vagrant up localdev
 
-The csw-catalog-service is now started, and the catalog can be accessed on `<http://10.20.30.10>`_. Unless you have already ingested some metadata, the catalog should be empty.
+The csw-catalog-service is now started, and the catalog can be accessed on `<http://10.20.30.11>`_. Unless you have already ingested some metadata, the catalog should be empty.
 
   .. note::
 
@@ -220,7 +226,7 @@ The csw-catalog-service is now started, and the catalog can be accessed on `<htt
 
   .. code-block:: bash
 
-    vagrant ssh
+    vagrant ssh localdev
 
 * Enter the docker container to run some code
 
@@ -246,18 +252,20 @@ You can now search the metadata catalog, e.g., using `QGIS <https://qgis.org/en/
 * Run ``qgis``
 * Select ``Web > MetaSearch > MetaSearch`` menu item
 * Select ``Services > New``
-* Type, e.g., ``testcatalog`` for the name
-* Type ``http://10.20.30.10`` for the URL
+* Type, e.g., ``localdev`` for the name
+* Type ``http://10.20.30.11`` for the URL
 * Under the ``Search`` tab, you can then add search parameters, click ``Search``, and get a list of available datasets.
 * Select a dataset
 * Click ``Add Data`` and select a WMS channel - the data will then be displayed in QGIS
 
-Contents of the S-ENDA-csw-catalog-service repository
-=====================================================
+..
+  Contents of the S-ENDA-csw-catalog-service repository
+  =====================================================
 
-* The file ``pycsw_local.dev.cfg`` is the pycsw configuration file used for local development. It contains configuration instructions to run the csw catalog service on your local Docker container which runs on the local virtual machine.
-* ``Vagrantfile`` is the vagrant configuration currently containing the development vm (TODO: add vm for non-development local testing)
-* ``Dockerfile.devel`` - Dockerfile for the development environment
-* ``build_container.dev.sh`` - shell script to add git repositories, run and set up volumes in the container ``catalog-dev``
-* ``docker-compose.*`` - docker-compose files to set up local test environment (not for development of tools) and run Continuous Integration
+..
+  * The file ``pycsw_local.dev.cfg`` is the pycsw configuration file used for local development. It contains configuration instructions to run the csw catalog service on your local Docker container which runs on the local virtual machine.
+  * ``Vagrantfile`` is the vagrant configuration currently containing the development vm (TODO: add vm for non-development local testing)
+  * ``Dockerfile.devel`` - Dockerfile for the development environment
+  * ``build_container.dev.sh`` - shell script to add git repositories, run and set up volumes in the container ``catalog-dev``
+  * ``docker-compose.*`` - docker-compose files to set up local test environment (not for development of tools) and run Continuous Integration
 

--- a/source/devel_environ.rst
+++ b/source/devel_environ.rst
@@ -251,5 +251,9 @@ You can now search the metadata catalog, e.g., using `QGIS <https://qgis.org/en/
 Contents of the S-ENDA-csw-catalog-service repository
 =====================================================
 
-* The file `pycsw_local.dev.cfg` is the pycsw configuration file used for local development. It contains configuration instructions to run the csw catalog service on your local Docker container which runs on the local virtual machine.
+* The file ``pycsw_local.dev.cfg`` is the pycsw configuration file used for local development. It contains configuration instructions to run the csw catalog service on your local Docker container which runs on the local virtual machine.
+* ``Vagrantfile`` is the vagrant configuration currently containing the development vm (TODO: add vm for non-development local testing)
+* ``Dockerfile.devel`` - Dockerfile for the development environment
+* ``build_container.dev.sh`` - shell script to add git repositories, run and set up volumes in the container ``catalog-dev``
+* ``docker-compose.*`` - docker-compose files to set up local test environment (not for development of tools) and run Continuous Integration
 

--- a/source/dm_recipes.rst
+++ b/source/dm_recipes.rst
@@ -44,13 +44,18 @@ When the new MMD file is added to the metadata repository, it will be translated
 Local test environment
 ----------------------
 
-This vm is used to test your MMD XML-files locally before pushing them to the main discovery metadata repository. Put your test files in the folder ``lib/input_mmd_xml_files``, then:
+This vm is used to test your MMD XML-files locally before pushing them to the main discovery metadata repository. 
 
 * Start VM:
 
   .. code-block:: bash
 
     vagrant up localtest
+
+Put your test files in the folder ``lib/input_mmd_xml_files``, then:
+
+  .. code-block:: bash
+
     vagrant ssh localtest
     cd /vagrant
     sudo MMD_IN=/vagrant/lib/input_mmd_xml_files ./deploy-metadata.sh

--- a/source/dm_recipes.rst
+++ b/source/dm_recipes.rst
@@ -113,10 +113,26 @@ DOI registration at MET
 Search context
 --------------
 
-User searches the catalog with opensearch
+User searches the catalog with OpenSearch
 =========================================
 
-TODO: test and describe..
+The ``localtest`` and ``localdev`` virtual machines provide OpenSearch support through `pyCSW <https://github.com/geopython/pycsw>`_. To test OpenSearch via the browser, start the ``localtest`` vm (``vagrant up localtest``) and go to the following address:
+
+* `<http://10.20.30.10/pycsw/csw.py?mode=opensearch&service=CSW&version=2.0.2&request=GetCapabilities>`_
+
+This will return a description document of the catalog service. The `URL` field in the description document is a template format that can be used to represent a parameterized form of the search. The search client will process the URL template and attempt to replace each instance of a template parameter, generally represented in the form {name}, with a value determined at query time (`OpenSearch URL template syntax <https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md#opensearch-url-template-syntax>`_). The question mark following any search parameter means that the parameter is optional.
+
+We can now find all datasets in the catalog:
+
+* `<http://10.20.30.10/?mode=opensearch&service=CSW&version=2.0.2&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results>`_
+
+Or datasets within a given time span:
+
+* `<http://10.20.30.10/?mode=opensearch&service=CSW&version=2.0.2&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results&time=2000-01-01/2020-09-01>`_
+
+Or, datasets from any of the Sentinel satellites:
+
+* `<http://10.20.30.10/?mode=opensearch&service=CSW&version=2.0.2&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results&q=sentinel>`_
 
 User searches web portals
 =========================

--- a/source/dm_recipes.rst
+++ b/source/dm_recipes.rst
@@ -9,36 +9,114 @@ Register context
 Data Provider registers dataset
 ===============================
 
-In order to make a dataset findable, a dataset must be registered in S-ENDA Metadata Service with appropriate metadata, which is indexed and exposed in CSW. The procedure is as follows:
+In order to make a dataset findable, a dataset must be registered in a searchable catalog with appropriate metadata. The (meta)data catalog is indexed and exposed through `CSW <https://en.wikipedia.org/wiki/Catalogue_Service_for_the_Web>`_. 
 
-#. Create MMD XML record of metadata
+The procedure to register a dataset in the catalog is as follows:
+
+#. Create `MMD <https://htmlpreview.github.io/?https://github.com/metno/mmd/blob/master/doc/mmd-specification.html>`_ XML record of metadata
 #. Translate from MMD to ISO19115
 #. Index in CSW
 #. Expose ISO19115 metadata via CSW to the internet
 
-This is done with the s-enda-find Virtual Machine (VM), for which a Vagrant configuration is available in https://github.com/metno/S-ENDA-Prototype.
+We have prepared Virtual Machine (VM) configurations and Docker containers to handle points 2-4 above.
 
-**TODO:** We need to describe how to do this:
+..
+  Note to reviewers: Please consider if this makes sense, and can be done now
 
-* manually in the VM
-* through the geoassets API
+The workflow which a data provider should follow in order to add new datasets to the common metadata catalog service is then as follows:
 
-S-ENDA Metadata Service gives feedback
-======================================
+#. Create `MMD <https://htmlpreview.github.io/?https://github.com/metno/mmd/blob/master/doc/mmd-specification.html>`_ XML record of metadata
+#. Clone the `S-ENDA-csw-catalog <https://github.com/metno/S-ENDA-csw-catalog-service>`_ repository
+#. Test your MMD XML file(s) using the localtest vm (:ref:`local-test-env`)
+#. Add an issue to the `S-ENDA-metadata <https://github.com/metno/S-ENDA-metadata>`_ repository (e.g., "New foo model dataset" [the issue is numbered, e.g., 131])
+#. Clone the `S-ENDA-metadata <https://github.com/metno/S-ENDA-metadata>`_ repository
+#. Create an issue branch: ``git branch issue131_foo_dataset``
+#. Add your MMD file in the new branch, then commit, push, and create a pull request
+#. A reviewer will evaluate the new dataset, and provide feedback or direcly accept and merge
 
-S-ENDA Metadata Service has two main types of feedback for the data provider:
+..
+  Note to reviewers: I now interpret http://senda1.lab-a.met.no as a staging server. How do we go from that to production, and what needs to be done? Please review and/or add issues in https://github.com/metno/S-ENDA-project-plan..
 
-#. Questions/praise/bug reports etc. from users.
-#. Operational metrics about downloads and production runs for each dataset.
+When the new MMD file is added to the metadata repository, it will be translated to a `pyCSW <https://github.com/geopython/pycsw>`_ ISO19139 profile, indexed in a postgis database, and exposed to the public via the `(meta)data catalog <http://senda1.lab-a.met.no/>`_ in the same way as demonstrated in the localtest vm (:ref:`local-test-env`).
 
-Feedback from users would come as either e-mails into a ticketing system, or as messages in a forum.
+.. _`local-test-env`:
 
-Operational metrics will be harvested from metrics server (e.g Prometheus),
-giving the data provider information such as number of downloads pr. day for each type of service(WMS, DAP etc.) and delays in producing the datasets.
+Local test environment
+----------------------
+
+This vm is used to test your MMD XML-files locally before pushing them to the main discovery metadata repository. Put your test files in the folder ``lib/input_mmd_xml_files``, then:
+
+* Start VM:
+
+  .. code-block:: bash
+
+    vagrant up localtest
+    vagrant ssh localtest
+    cd /vagrant
+    sudo MMD_IN=/vagrant/lib/input_mmd_xml_files ./deploy-metadata.sh
+
+.. note::
+
+  The three last commands above should be handled through the provisioning but this currently does not work...
+
+..
+  * Check that the postgis db is added
+
+..
+  .. code-block:: bash
+
+..
+    vagrant ssh localtest
+    cd /vagrant/
+    sudo docker-compose exec postgis bash
+    psql -U postgis csw_db
+    \dt
+    select * from records;
+
+The csw-catalog-service is now started, and the catalog can be accessed on `<http://10.20.30.10>`_. Note that there is no point in debugging or changing code used in this environment. It is only meant to test the content of `S-ENDA-metadata <https://github.com/metno/S-ENDA-metadata>`_. If you want to modify code used in the catalog service, please refer to :ref:`local-developmen-env`.
+
+Search the metadata catalog using `QGIS <https://qgis.org/en/site/>`_ (v3.14 or higher):
+
+* `Download and install QGIS <https://qgis.org/en/site/forusers/download.html>`_
+* Run ``qgis``
+* Select ``Web > MetaSearch > MetaSearch`` menu item
+* Select ``Services > New``
+* Type, e.g., ``localtest`` for the name
+* Type ``http://10.20.30.10`` for the URL
+* Under the ``Search`` tab, you can then add search parameters, click ``Search``, and get a list of available datasets.
+* Select a dataset
+* Click ``Add Data`` and select a WMS channel - the data will then be displayed in QGIS
+
+..
+  S-ENDA Metadata Service gives feedback
+  ======================================
+
+..
+  S-ENDA Metadata Service has two main types of feedback for the data provider:
+
+..
+  #. Questions/praise/bug reports etc. from users.
+  #. Operational metrics about downloads and production runs for each dataset.
+
+..
+  Feedback from users would come as either e-mails into a ticketing system, or as messages in a forum.
+
+..
+  Operational metrics will be harvested from metrics server (e.g Prometheus), giving the data provider information such as number of downloads pr. day for each type of service(WMS, DAP etc.) and delays in producing the datasets.
+
+DOI registration at MET
+=======================
+
+.. include:: doi_at_met.rst
 
 --------------
 Search context
 --------------
+
+User searches the catalog with opensearch
+=========================================
+
+TODO: test and describe..
 
 User searches web portals
 =========================
@@ -48,13 +126,10 @@ GeoNorge.no
 
 **TODO:** describe how to search in geonorge, possibly with screenshots
 
-User searches S-ENDA Metadata Service system
-============================================
+User searches from QGIS
+=======================
 
-CSW Protocol
-------------
-
-A prototype catalogue service of S-ENDA Metadata Service is available at http://senda1.lab-a.met.no:8000/. This can, e.g., be used from QGIS, as follows:
+A staging server for the CSW catalog service is available at http://senda1.lab-a.met.no:8000/. This can be used from QGIS, as follows:
 
 * Select ``Web > MetaSearch > MetaSearch`` menu item
 * Select ``Services > New``
@@ -63,8 +138,3 @@ A prototype catalogue service of S-ENDA Metadata Service is available at http://
 
 Under the ``Search`` tab, you can then add search parameters, click ``Search``, and get a list of available datasets.
 
------------------------
-DOI registration at MET
------------------------
-
-.. include:: doi_at_met.rst

--- a/source/dm_recipes.rst
+++ b/source/dm_recipes.rst
@@ -92,6 +92,10 @@ Search the metadata catalog using `QGIS <https://qgis.org/en/site/>`_ (v3.14 or 
 * Select a dataset
 * Click ``Add Data`` and select a WMS channel - the data will then be displayed in QGIS
 
+.. note::
+
+  If you get an error about unexpected keyword argument 'auth' when searching for data, it is most likely due to a bug in QGIS: `<https://github.com/qgis/QGIS/issues/38074>`_
+
 ..
   S-ENDA Metadata Service gives feedback
   ======================================

--- a/source/dm_recipes.rst
+++ b/source/dm_recipes.rst
@@ -130,6 +130,10 @@ Or datasets within a given time span:
 
 * `<http://10.20.30.10/?mode=opensearch&service=CSW&version=2.0.2&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results&time=2000-01-01/2020-09-01>`_
 
+.. note::
+
+  pyCSW opensearch time queries do not relate to the "expected" ``start_date`` and ``end_date`` MMD fields, or the associated ``beginPosition`` and ``endPosition``, in the pyCSW ISO19139 profile. We are working to understand and handle this...
+
 Or, datasets from any of the Sentinel satellites:
 
 * `<http://10.20.30.10/?mode=opensearch&service=CSW&version=2.0.2&request=GetRecords&elementsetname=full&typenames=csw:Record&resulttype=results&q=sentinel>`_

--- a/source/frost.rst
+++ b/source/frost.rst
@@ -1,5 +1,5 @@
-Heritage system: Frost
-""""""""""""""""""""""
+Frost
+=====
 
 .. Insert the name of the heritage metadata system in the above heading. No   
    other text should go under
@@ -7,7 +7,7 @@ Heritage system: Frost
 
 
 Responsible (Who?)
-==================
+------------------
 
 .. Required. Who is responsible for this heritage system. This can be a 
    group, a role or an administrative unit. Try to avoid linking to specific  
@@ -16,7 +16,7 @@ Responsible (Who?)
 MET Norway, Department of Observation and Climate, Division for Observation quality and data processing.
 
 Description (What?)
-===================
+-------------------
 
 .. Required. Short description of the system: 
    - what types of metadata is stored in this system.
@@ -30,7 +30,7 @@ from KDVH (Klimadatavarehuset). An element is for example temperature at 2m or w
 a specific location and at a time.
 
 Documentation(Where/how?)
-=========================
+-------------------------
 
 .. Required. Links to system dokumentation as comments, mark links that are 
    only available for internal users
@@ -38,7 +38,7 @@ Documentation(Where/how?)
 Frost is documented with swagger. See https://frost.met.no/api.html for more information.
 
 Conditions and dependencies(why?)
-=================================
+---------------------------------
 
 .. Required. Please add a short paragraph explaining in words why the system is as it is
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -15,6 +15,8 @@ Welcome to S-ENDA's documentation!
    architecture
    metadata_management_heritage
    use_cases
+
+..
    catalog_service_API
 
 .. toctree::

--- a/source/meta_heritage_template.rst
+++ b/source/meta_heritage_template.rst
@@ -1,5 +1,6 @@
-Heritage system: Template
-""""""""""""""""""""""""""
+--------------------------------------------------------------------
+Template for description of heritage systems used in data management
+--------------------------------------------------------------------
 
 .. Insert the name of the heritage metadata system in the above heading. No   
    other text should go under
@@ -7,7 +8,7 @@ Heritage system: Template
 
 
 Responsible(Who?)
-==================
+=================
 
 .. Required. Who is responsible for this heritage system. This can be a 
    group, a role or an administrative unit. Try to avoid linking to specific  

--- a/source/metadata_management_heritage.rst
+++ b/source/metadata_management_heritage.rst
@@ -16,17 +16,13 @@ MET Norway
    mmd
    productstatus
 
-Project partner x
-==================
-
-TODO: fill in...
-
-Project partner y
-==================
-
-TODO: fill in...
-
-Project partner z
-==================
-
-TODO: fill in...
+..
+  Project partner x
+  ==================
+  TODO: fill in...
+  Project partner y
+  ==================
+  TODO: fill in...
+  Project partner z
+  ==================
+  TODO: fill in...

--- a/source/metadata_management_heritage.rst
+++ b/source/metadata_management_heritage.rst
@@ -1,14 +1,19 @@
+===============================
 Heritage of metadata management
-""""""""""""""""""""""""""""""""
-
-MET Norway
-==========
+===============================
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contents
 
    meta_heritage_template
+
+----------
+MET Norway
+----------
+
+.. toctree::
+   :maxdepth: 1
+
    service_catalog
    stinfosys
    api.met.no

--- a/source/mmd.rst
+++ b/source/mmd.rst
@@ -1,21 +1,21 @@
 Heritage system: MMD
-"""""""""""""""""""""
+====================
 
 .. Insert the name of the heritage metadata system in the above heading. No   
    other text should go under
    this heading.
  
 Responsible(Who?)
-==================
+-----------------
 
 .. Required. Who is responsible for this heritage system. This can be a 
    group, a role or an administrative unit. Try to avoid linking to specific  
    persons.
 
-* Øystein Godøy
+* Øystein Godøy / FoU-FD
 
 Description(What?)
-==================
+------------------
 
 .. Required. Short description of the system: 
    - what types of metadata is stored in this system.
@@ -27,7 +27,7 @@ The Metno Metadata Format (MMD) is an XML metadata format for storing informatio
 The MMD covers a wide range of metadata types and is compatible with ISO19115 and GCMD DIF.
 
 Documentation(Where/how?)
-=========================
+-------------------------
 
 .. Required. Links to system dokumentation as comments, mark links that are 
    only available for internal users
@@ -36,7 +36,7 @@ Documentation for the MMD format can be found in the mmd repository on GitHub: h
 
 
 Conditions and dependencies(why?)
-=================================
+---------------------------------
 
 .. Required. Please add a short paragraph explaining in words why the system is as it is
 

--- a/source/productstatus.rst
+++ b/source/productstatus.rst
@@ -1,5 +1,5 @@
 Productstatus
-^^^^^^^^^^^^^^
+=============
 
 TODO: write or link to documentation about product status.
 

--- a/source/service_catalog.rst
+++ b/source/service_catalog.rst
@@ -1,5 +1,5 @@
 Service catalog
-""""""""""""""""
+===============
 
 TODO: write or link to documentation about the service catalog.
 

--- a/source/stinfosys.rst
+++ b/source/stinfosys.rst
@@ -1,12 +1,12 @@
-Heritage system: Stinfosys
-"""""""""""""""""""""""""""
+Stinfosys
+=========
 
 .. Insert the name of the heritage metadata system in the above heading. No   
    other text should go under
    this heading.
  
 Responsible (Who?)
-==================
+------------------
 
 .. Required. Who is responsible for this heritage system. This can be a 
    group, a role or an administrative unit. Try to avoid linking to specific  
@@ -19,7 +19,7 @@ Responsible (Who?)
  * Content management: OKD
 
 Description (What?)
-===================
+-------------------
 
 .. Required. Short description of the system: 
    - what types of metadata is stored in this system.
@@ -38,7 +38,7 @@ and a small amount of information for some stations outside Norway.
 * Message: communication of data from the stations to MET
 
 Documentation (Where/how?)
-==========================
+--------------------------
 
 .. Required. Links to system dokumentation as comments, mark links that are 
    only available for internal users
@@ -58,7 +58,7 @@ written in Norwegian.
 
 
 Conditions and dependencies (why?)
-==================================
+----------------------------------
 
 .. Required. Please add a short paragraph explaining in words why the system is as it is
 


### PR DESCRIPTION
Documentation for local development and testing focused on ingestion of MMD in the csw catalog service (https://github.com/metno/S-ENDA-csw-catalog-service).

To reviewers:
- please consider the suggested workflow
- please test with your own MMD files
- and comment where needed.. 

The compiled docs are available here: https://s-enda-documentation.readthedocs.io/en/catalog_service_docs/

Note:

"Add data" in QGIS doesn't work for me at the moment. I'm unsure if the link to GetCapabilities is wrong
- http://nbswms.met.no/thredds/wms_ql/NBS/S1A/2020/04/20/EW/S1A_EW_GRDM_1SDH_20200420T023244_20200420T023348_032205_03B97F_72EB.nc?SERVICE=WMS&amp;REQUEST=GetCapabilities

This works in the browser if you replace `&amp;` with `&` 
- http://nbswms.met.no/thredds/wms_ql/NBS/S1A/2020/04/20/EW/S1A_EW_GRDM_1SDH_20200420T023244_20200420T023348_032205_03B97F_72EB.nc?SERVICE=WMS&REQUEST=GetCapabilities